### PR TITLE
Avoid kernel oops when restoring line discipline

### DIFF
--- a/sllin/sllin.c
+++ b/sllin/sllin.c
@@ -620,7 +620,6 @@ static int sll_open(struct net_device *dev)
 static void sll_free_netdev(struct net_device *dev)
 {
 	int i = dev->base_addr;
-	free_netdev(dev);
 	#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 11, 9)
 		free_netdev(dev);
 	#endif


### PR DESCRIPTION
There is an excess call to `free_netdev` in the `sll_free_netdev` which results in a kernel oops when either explicitly restroring the line discipline or unloading the module.  Starting with 4.11.9 this is handled internally in `netdev_run_todo` in net/core/dev.c after setting `needs_free_netdev`. For versions before 4.11.9, there is already a call to `netdev_free` in `sll_free_netdev`.

67a08d3 is more of a cosmetic suggestion which probably doesn't have too much of an impact on anything. Still, I'd argue it's a worthwhile change to avoid potential future mishaps.