### PR TITLE
Fix crash wich occurs on newer kernels somewhere after kernel version…

### DIFF
--- a/sllin/sllin.c
+++ b/sllin/sllin.c
@@ -1556,6 +1556,7 @@ static struct sllin *sll_alloc(dev_t line)
 	int i;
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 4, 0)
 	int size;
+	struct can_ml_priv *can_ml;
 #endif
 	struct net_device *dev = NULL;
 	struct sllin       *sl;
@@ -1602,7 +1603,8 @@ static struct sllin *sll_alloc(dev_t line)
 
 	sl = netdev_priv(dev);
 	#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 4, 0)
-		dev->ml_priv = (void *)sl + ALIGN(sizeof(*sl), NETDEV_ALIGN);
+		can_ml = (void *)sl + ALIGN(sizeof(*sl), NETDEV_ALIGN);
+		can_set_ml_priv(dev, can_ml);
 	#endif
 	/* Initialize channel control data */
 	sl->magic = SLLIN_MAGIC;


### PR DESCRIPTION
… 4.10.

For newer kernel versions it seems that the property ml_priv_type needs to be set
for net devices. If not set can_dev_rcv_lists_find(net, dev) returns NULL in
can_rx_register() and crashes subsequently.

Now the helper function can_set_ml_priv is used for setting ml_priv and ml_priv_type, 
similar as it is done in slcan.c

Fixes Issue #10.