### PR TITLE
sllin: fix 'NOHZ tick-stop error' on kernels < 5.18

### DIFF
--- a/sllin/sllin.c
+++ b/sllin/sllin.c
@@ -434,7 +434,13 @@ static void sllin_send_canfr(struct sllin *sl, canid_t id, char *data, int len)
 	skb->ip_summed = CHECKSUM_UNNECESSARY;
 	memcpy(skb_put(skb, sizeof(struct can_frame)),
 	       &cf, sizeof(struct can_frame));
-	netif_rx(skb);
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 18, 0)
+	if (!in_interrupt())
+		netif_rx_ni(skb);
+	else
+#endif
+		netif_rx(skb);
 
 	sl->dev->stats.rx_packets++;
 	sl->dev->stats.rx_bytes += cf.can_dlc;


### PR DESCRIPTION
The slin_send_canfr() function is called for different reasons, and in particular both in interrupt and thread context. In the latter case, pre-5.18 kernels complain with 'NOHZ tick-stop error: Non-RCU local softirq work is pending', as the netif_rx() function is meant to be called only as part of an interrupt service routine.

Fix the issue above calling netif_rx_ni() instead of netif_rx() when not in an interrupt context.

Limit this behaviour to kernels older than 5.18, since starting with this version netif_rx() can be called in any context and netif_rx_ni() has been removed entirely in:

2655926aea9b: net: Remove netif_rx_any_context() and netif_rx_ni()

Signed-off-by: Francesco Valla <francesco.valla@mta.it>