### PR TITLE
Linux6

### DIFF
--- a/sllin/sllin.c
+++ b/sllin/sllin.c
@@ -1817,8 +1817,13 @@ static void sllin_hangup(struct tty_struct *tty)
 #endif
 
 /* Perform I/O control on an active SLLIN channel. */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 16, 0)
 static int sllin_ioctl(struct tty_struct *tty, struct file *file,
 		       unsigned int cmd, unsigned long arg)
+#else /* >= 5.16.0 */
+static int sllin_ioctl(struct tty_struct *tty,
+		       unsigned int cmd, unsigned long arg)
+#endif
 {
 	struct sllin *sl = (struct sllin *) tty->disc_data;
 	unsigned int tmp;
@@ -1838,7 +1843,11 @@ static int sllin_ioctl(struct tty_struct *tty, struct file *file,
 		return -EINVAL;
 
 	default:
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 16, 0)
 		return tty_mode_ioctl(tty, file, cmd, arg);
+#else /* >= 5.16.0 */
+		return tty_mode_ioctl(tty, cmd, arg);
+#endif
 	}
 }
 

--- a/sllin/sllin.c
+++ b/sllin/sllin.c
@@ -1803,11 +1803,18 @@ static void sllin_close(struct tty_struct *tty)
 	/* This will complete via sl_free_netdev */
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0)
 static int sllin_hangup(struct tty_struct *tty)
 {
 	sllin_close(tty);
 	return 0;
 }
+#else /* >= 5.17.0 */
+static void sllin_hangup(struct tty_struct *tty)
+{
+	sllin_close(tty);
+}
+#endif
 
 /* Perform I/O control on an active SLLIN channel. */
 static int sllin_ioctl(struct tty_struct *tty, struct file *file,


### PR DESCRIPTION
Hi,

There have been minor changes in Linux 5.16 and 5.17 breaking the build.
Description is here:
tty_mode_ioctl: https://elixir.bootlin.com/linux/v5.16.20/source/include/linux/tty.h
hangup: https://elixir.bootlin.com/linux/v5.17.15/source/include/linux/tty_ldisc.h

I have tested the modifications on Linux 5.19 (Ubuntu 22.04 LTS) and the module works fine.
It also builds on Linux 6.2, but I could not fully test the module there.

Since older kernels are still maintained, the modifications I made are included between #if KERNEL_VERSION_CODE / #endif directives.

Best regards,
CK